### PR TITLE
Fix error when building metabase

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
     hostname: metabase
     volumes:
       - /dev/urandom:/dev/random:ro
-      - $PWD:/metabase-data
+      - $PWD/:/metabase-data
       - $PWD/data:/data
     ports:
       - 3000:3000


### PR DESCRIPTION
Creating metabase ... error

ERROR: for metabase  Cannot create container for service metabase-app: create .: volume name is too short, names should be at least two alphanumeric characters

ERROR: for metabase-app  Cannot create container for service metabase-app: create .: volume name is too short, names should be at least two alphanumeric characters
ERROR: Encountered errors while bringing up the project.