### PR TITLE
Support for raspberry pi image

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,4 +52,4 @@ When a value is entered in the DCA field (top left), the DCA quantity and the DC
 * The metabase image is built for x86.
 Therefore, on Raspberry Pi, a new image needs to be created using an ARM based image.
 * I created a `Dockerfile` that creates this kind of image, which supposed to be identical to the `metabase` one.
-* To use the new image, replace line 13 of `docker-compose.yml` from `image: metabase/metabase:v0.43.1` to `build: metabase_rpi`
+* To use the new image, replace line 13 of `docker-compose.yml` from `image: metabase/metabase:latest` to `build: metabase_rpi`

--- a/README.md
+++ b/README.md
@@ -47,3 +47,9 @@ When a value is entered in the DCA field (top left), the DCA quantity and the DC
 # Multiple dashboard
 * If you want to deploy a second dashboard instance on the same machine, please clone the repo and update the `config.json` and `docker-compose.yaml` files.
 * In the `docker-compose.yaml` you'll have to modify container names, exposed port and network interface. An example is provided in `docker-compose.yaml.example-second-dashboard` 
+
+# Running on Raspberry Pi
+* The metabase image is built for x86.
+Therefore, on Raspberry Pi, a new image needs to be created using an ARM based image.
+* I created a `Dockerfile` that creates this kind of image, which supposed to be identical to the `metabase` one.
+* To use the new image, replace line 13 of `docker-compose.yml` from `image: metabase/metabase:v0.43.1` to `build: metabase_rpi`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       - /etc/timezone:/etc/timezone:ro
       - /etc/localtime:/etc/localtime:ro
   metabase-app:
-    image: metabase/metabase:v0.43.1
+    build: metabase_rpi
     container_name: metabase
     hostname: metabase
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       - /etc/timezone:/etc/timezone:ro
       - /etc/localtime:/etc/localtime:ro
   metabase-app:
-    build: metabase_rpi
+    image: metabase/metabase:v0.43.1
     container_name: metabase
     hostname: metabase
     volumes:

--- a/metabase_rpi/Dockerfile
+++ b/metabase_rpi/Dockerfile
@@ -1,0 +1,30 @@
+FROM ubuntu:22.04
+
+ENV FC_LANG en-US LC_CTYPE en_US.UTF-8
+
+# dependencies
+RUN apt-get update -yq && apt-get install -yq bash fonts-dejavu-core fonts-dejavu-extra fontconfig curl openjdk-11-jre-headless && \
+    apt-get clean && \
+    rm -rf /var/lib/{apt,dpkg,cache,log}/ && \
+    mkdir -p /app/certs && \
+    curl https://s3.amazonaws.com/rds-downloads/rds-combined-ca-bundle.pem -o /app/certs/rds-combined-ca-bundle.pem  && \
+    keytool -noprompt -import -trustcacerts -alias aws-rds -file /app/certs/rds-combined-ca-bundle.pem -keystore /etc/ssl/certs/java/cacerts -keypass changeit -storepass changeit && \
+    curl https://cacerts.digicert.com/DigiCertGlobalRootG2.crt.pem -o /app/certs/DigiCertGlobalRootG2.crt.pem  && \
+    keytool -noprompt -import -trustcacerts -alias azure-cert -file /app/certs/DigiCertGlobalRootG2.crt.pem -keystore /etc/ssl/certs/java/cacerts -keypass changeit -storepass changeit && \
+    mkdir -p /plugins && chmod a+rwx /plugins && \
+    useradd --shell /bin/bash metabase
+
+
+WORKDIR /app
+
+# copy app from the official image
+COPY --from=metabase/metabase:latest /app /app
+
+RUN chown -R metabase /app
+
+USER metabase
+# expose our default runtime port
+EXPOSE 3000
+
+# run it
+ENTRYPOINT ["/app/run_metabase.sh"]


### PR DESCRIPTION
I tried running the dashboard on my raspberry pi and discovered the `metabase` image only supports x86.
I followed the advices on the internet and created an image compatible with raspberry pi...