### PR TITLE
Ignore invalid bybit request

### DIFF
--- a/scraper_root/scraper/bybitderivatives.py
+++ b/scraper_root/scraper/bybitderivatives.py
@@ -2,6 +2,8 @@ import logging
 import threading
 import time
 import datetime
+
+import pybit
 from dateutil import parser
 from typing import List
 
@@ -101,7 +103,11 @@ class BybitDerivatives:
                 self.activesymbols = ["BTCUSDT"]
                 positions = []
                 for i in self.linearsymbols:
-                    exchange_position = self.rest_manager2.my_position(symbol="{}".format(i))
+                    try:
+                        exchange_position = self.rest_manager2.my_position(symbol="{}".format(i))
+                    except pybit.InvalidRequestError as e:
+                        logger.error(f'{self.alias}: Failed to get symbol position: {e}')
+                        continue
                     for x in exchange_position['result']:
                         if x['position_value'] != 0:  # filter only items that have positions
                             if x['side'] == "Buy":  # recode buy / sell into long / short


### PR DESCRIPTION
Recently bybit delisted ZBCUSDT from perpetual, causing this exception to be raised and ignore some positions:
```python
scraper_1       | 2023-10-19 19:01:36 ERROR    account: Failed to process positions: Closed symbol error: this zbcusdt contract is not live (ErrCode: 30078) (ErrTime: 19:01:36).
scraper_1       | Request → GET https://api.bybit.com/private/linear/position/list: {'api_key': '****', 'recv_window': 5000, 'symbol': 'ZBCUSDT', 'timestamp': 1697742095818, 'sign': '****'}.
```
This fix should catch the exception and continue to the next symbol instead of stopping the entire loop iteration on symbols