### PR TITLE
Bugfix: Reduce window for positions query by 1 day

### DIFF
--- a/scraper_root/scraper/bybitderivatives.py
+++ b/scraper_root/scraper/bybitderivatives.py
@@ -242,7 +242,7 @@ class BybitDerivatives:
         one_day_ms = 24 * 60 * 60 * 1000
         while True:
             try:
-                two_years_ago = (datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(days=2*365))
+                two_years_ago = (datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(days=2*365-1))
                 two_years_ago = int(two_years_ago.timestamp() * 1000)
 
                 counter = 0


### PR DESCRIPTION
Solves this error:
```python
2025-03-19 21:37:47 ERROR    Failed to process trades: Can't query order earlier than 2 years, please check your params: startTime or endTime! (ErrCode: 10001) 
37:47).
Request → GET https://api.bybit.com/v5/position/closed-pnl: category=linear&limit=100&startTime=1679348267087.
Traceback (most recent call last):
  File "/scraper/scraper_root/scraper/bybitderivatives.py", line 323, in sync_trades
    exchange_incomes = self.rest_manager2.get_closed_pnl(category="linear", limit='100', startTime=newest_timestamp + 1)
  File "/usr/local/lib/python3.10/site-packages/pybit/_v5_position.py", line 243, in get_closed_pnl
    return self._submit_request(
  File "/usr/local/lib/python3.10/site-packages/pybit/_http_manager.py", line 367, in _submit_request
    raise InvalidRequestError(
pybit.exceptions.InvalidRequestError: Can't query order earlier than 2 years, please check your params: startTime or endTime! (ErrCode: 10001) (ErrTime: 21:37:47).
Request → GET https://api.bybit.com/v5/position/closed-pnl: category=linear&limit=100&startTime=1679348267087.
```