### PR TITLE
Pin Metabase to v0.59.1 and bind to localhost only

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,18 @@ When a value is entered in the DCA field (top left), the DCA quantity and the DC
 * Enter the api-key & secret
   * `nano config.json`
 * Start the dashboard
-  * Run `docker-compose up -d`
-* Go to http://localhost:3000
+  * Run `docker compose up -d`
+* Go to http://localhost:30000
+
+# Remote access via SSH tunnel
+
+Metabase is bound to `127.0.0.1` (localhost only) and is **not** exposed to the public internet. This is intentional — Metabase has had multiple critical CVEs including pre-auth remote code execution vulnerabilities (e.g. CVE-2023-38646, CVE-2023-37470, CVE-2023-32680). Exposing Metabase directly to the internet is a significant security risk.
+
+To access the dashboard from another machine, use an SSH tunnel:
+```
+ssh -L 30000:localhost:30000 user@your-server-ip
+```
+Then open `http://localhost:30000` in your browser. The dashboard is accessible as long as the SSH session is open.
 
 | WARNING: If you change the config.json file, make sure you rebuild the container using `docker-compose up -d --build` |
 | --- |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,8 +10,7 @@ services:
       - /etc/timezone:/etc/timezone:ro
       - /etc/localtime:/etc/localtime:ro
   metabase-app:
-    image: metabase/metabase:latest
-#    image: metabase/metabase:v0.43.1
+    image: metabase/metabase:v0.59.1
     container_name: metabase
     hostname: metabase
     volumes:
@@ -19,7 +18,7 @@ services:
       - $PWD:/metabase-data
       - $PWD/data:/data
     ports:
-      - 3000:3000
+      - 127.0.0.1:30000:3000
     environment:
       MB_DB_FILE: /metabase-data/metabase.db
     networks:


### PR DESCRIPTION
Metabase has had critical CVEs (CVE-2023-38646, CVE-2023-37470, CVE-2023-32680) including pre-auth RCE. Pin to v0.59.1 instead of :latest and bind port to 127.0.0.1 so it's not exposed to the internet. Added SSH tunnel instructions to README.